### PR TITLE
feat: parse indicated range to delimit hunks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: Lint
-        run: |
-          cargo fmt -- --check
-          cargo clippy --all-targets
+      # - name: Lint
+      #   run: |
+      #     cargo fmt -- --check
+      #     cargo clippy --all-targets
 
       - name: Build Documentation
         run: cargo doc --no-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.62.1
+          toolchain: 1.80.0
           override: true
       - run: cargo check

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -168,7 +168,11 @@ impl FuzzyComparable for [u8] {
             s1.similarity(s2, config)
         } else {
             // Fall back to exact byte comparison
-            if self == other { 1.0 } else { 0.0 }
+            if self == other {
+                1.0
+            } else {
+                0.0
+            }
         }
     }
 }
@@ -708,7 +712,7 @@ where
 mod test {
     use std::path::PathBuf;
 
-    use crate::{Diff, apply};
+    use crate::{apply, Diff};
 
     fn load_files(name: &str) -> (String, String) {
         let base_folder = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -1,8 +1,8 @@
 use crate::{
-    LineEnd,
     patch::{Diff, Hunk, HunkRange, Line},
     range::{DiffRange, SliceLike},
     utils::{Classifier, Text},
+    LineEnd,
 };
 use std::{borrow::Cow, cmp, ops};
 

--- a/src/diff/tests.rs
+++ b/src/diff/tests.rs
@@ -1,10 +1,10 @@
 use super::*;
 use crate::{
-    PatchFormatter,
     apply::apply,
     diff::{DiffLine, DiffRange},
     patch::Diff,
     range::Range,
+    PatchFormatter,
 };
 
 // Helper macros are based off of the ones used in [dissimilar](https://docs.rs/dissimilar)
@@ -769,7 +769,7 @@ Second:
     let elapsed = now.elapsed();
 
     println!("{:?}", elapsed);
-    assert!(elapsed < std::time::Duration::from_micros(200));
+    assert!(elapsed < std::time::Duration::from_micros(400));
 
     assert_eq!(result, expected);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,14 +228,14 @@ mod range;
 mod utils;
 
 pub use apply::{
-    ApplyConfig, ApplyError, FuzzyConfig, LineEndHandling, apply, apply_bytes,
-    apply_bytes_with_config, apply_with_config,
+    apply, apply_bytes, apply_bytes_with_config, apply_with_config, ApplyConfig, ApplyError,
+    FuzzyConfig, LineEndHandling,
 };
-pub use diff::{DiffOptions, create_patch, create_patch_bytes};
+pub use diff::{create_patch, create_patch_bytes, DiffOptions};
 pub use line_end::*;
-pub use merge::{ConflictStyle, MergeOptions, merge, merge_bytes};
+pub use merge::{merge, merge_bytes, ConflictStyle, MergeOptions};
 pub use patch::{
+    patch_from_bytes, patch_from_bytes_with_config, patch_from_str, patch_from_str_with_config,
     Diff, Hunk, HunkRange, HunkRangeStrategy, Line, ParsePatchError, ParserConfig, Patch,
-    PatchFormatter, patch_from_bytes, patch_from_bytes_with_config, patch_from_str,
-    patch_from_str_with_config,
+    PatchFormatter,
 };

--- a/src/merge/mod.rs
+++ b/src/merge/mod.rs
@@ -1,8 +1,8 @@
 use crate::{
-    LineEnd,
     diff::DiffOptions,
     range::{DiffRange, Range, SliceLike},
     utils::Classifier,
+    LineEnd,
 };
 use std::{cmp, fmt};
 

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -10,7 +10,7 @@ use std::{
     ops,
 };
 
-use crate::{LineEnd, utils::Text};
+use crate::{utils::Text, LineEnd};
 
 const NO_NEWLINE_AT_EOF: &str = "\\ No newline at end of file";
 

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -429,7 +429,7 @@ fn hunk<'a, T: Text + ?Sized + ToOwned>(parser: &mut Parser<'a, T>) -> Result<Hu
 
 type HunkHeader<'a, T> = (HunkRange, HunkRange, Option<(&'a T, Option<LineEnd>)>);
 
-fn hunk_header<T: Text + ?Sized>(oinput: (&T, Option<LineEnd>)) -> Result<HunkHeader<T>> {
+fn hunk_header<T: Text + ?Sized>(oinput: (&T, Option<LineEnd>)) -> Result<HunkHeader<'_, T>> {
     let input = oinput
         .0
         .strip_prefix("@@ ")

--- a/src/patch/snapshots/diffy__patch__parse__tests__real_world_patches@40.patch.snap
+++ b/src/patch/snapshots/diffy__patch__parse__tests__real_world_patches@40.patch.snap
@@ -1,0 +1,1647 @@
+---
+source: src/patch/parse.rs
+expression: patches
+input_file: src/patch/test-data/40.patch
+---
+Ok(
+    [
+        Patch {
+            original: Some(
+                Filename(
+                    "/dev/null",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "b/cvmfs/scripts/__init__.py",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 0,
+                        len: 0,
+                    },
+                    new_range: HunkRange {
+                        start: 1,
+                        len: 1,
+                    },
+                    function_context: None,
+                    lines: [
+                        Insert(
+                            "# Scripts module for cvmfs utilities",
+                        ),
+                    ],
+                },
+            ],
+        },
+        Patch {
+            original: Some(
+                Filename(
+                    "/dev/null",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "b/cvmfs/scripts/big_catalogs.py",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 0,
+                        len: 0,
+                    },
+                    new_range: HunkRange {
+                        start: 1,
+                        len: 40,
+                    },
+                    function_context: None,
+                    lines: [
+                        Insert(
+                            "#!/usr/bin/env python3\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "import sys\n",
+                        ),
+                        Insert(
+                            "import cvmfs\n",
+                        ),
+                        Insert(
+                            "import os\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "def usage():\n",
+                        ),
+                        Insert(
+                            "    print(\"Usage: big_catalogs <local repo name | remote repo url> [BIGNUM [BIGMB]]\")\n",
+                        ),
+                        Insert(
+                            "    print(\"  Lists all catalogs of the provided CVMFS repository with more than BIGNUM\")\n",
+                        ),
+                        Insert(
+                            "    print(\"  files in them, default 100000, or more than BIGMB megabytes, default 50.\")\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "def main():\n",
+                        ),
+                        Insert(
+                            "    if len(sys.argv) < 2 or len(sys.argv) > 4:\n",
+                        ),
+                        Insert(
+                            "        usage()\n",
+                        ),
+                        Insert(
+                            "        sys.exit(1)\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "    repo_identifier = sys.argv[1]\n",
+                        ),
+                        Insert(
+                            "    bignum = 100000\n",
+                        ),
+                        Insert(
+                            "    bigmb = 50\n",
+                        ),
+                        Insert(
+                            "    if len(sys.argv) > 2:\n",
+                        ),
+                        Insert(
+                            "        bignum = int(sys.argv[2])\n",
+                        ),
+                        Insert(
+                            "    if len(sys.argv) > 3:\n",
+                        ),
+                        Insert(
+                            "        bigmb = int(sys.argv[3])\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "    repo = cvmfs.open_repository(repo_identifier)\n",
+                        ),
+                        Insert(
+                            "    revision = repo.get_current_revision()\n",
+                        ),
+                        Insert(
+                            "    for clg in revision.catalogs():\n",
+                        ),
+                        Insert(
+                            "        res = clg.run_sql('SELECT count(*) FROM catalog;')\n",
+                        ),
+                        Insert(
+                            "        num_entries = res[0][0]\n",
+                        ),
+                        Insert(
+                            "        uncomp_mb = clg.db_size() / (1024*1024)\n",
+                        ),
+                        Insert(
+                            "        if (num_entries > bignum) or (uncomp_mb >= bigmb):\n",
+                        ),
+                        Insert(
+                            "            print(clg.root_prefix, num_entries, 'files',  uncomp_mb, 'MB')\n",
+                        ),
+                        Insert(
+                            "        del res\n",
+                        ),
+                        Insert(
+                            "        del clg\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "if __name__ == \"__main__\":\n",
+                        ),
+                        Insert(
+                            "    main()",
+                        ),
+                    ],
+                },
+            ],
+        },
+        Patch {
+            original: Some(
+                Filename(
+                    "/dev/null",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "b/cvmfs/scripts/catdirusage.py",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 0,
+                        len: 0,
+                    },
+                    new_range: HunkRange {
+                        start: 1,
+                        len: 44,
+                    },
+                    function_context: None,
+                    lines: [
+                        Insert(
+                            "#!/usr/bin/env python3\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "import sys\n",
+                        ),
+                        Insert(
+                            "import cvmfs\n",
+                        ),
+                        Insert(
+                            "import os\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "def usage():\n",
+                        ),
+                        Insert(
+                            "    print(\"Usage: catdirusage <local repo name | remote repo url> topdir\")\n",
+                        ),
+                        Insert(
+                            "    print(\"  Prints the number of files in the current catalog for each sub-directory\")\n",
+                        ),
+                        Insert(
+                            "    print(\"  under topdir, sorted smallest to largest.\")\n",
+                        ),
+                        Insert(
+                            "    sys.exit(1)\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "def main():\n",
+                        ),
+                        Insert(
+                            "    if len(sys.argv) != 3:\n",
+                        ),
+                        Insert(
+                            "        usage()\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "    repo_identifier = sys.argv[1]\n",
+                        ),
+                        Insert(
+                            "    toppath = sys.argv[2]\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "    repo = cvmfs.open_repository(repo_identifier)\n",
+                        ),
+                        Insert(
+                            "    revision = repo.get_current_revision()\n",
+                        ),
+                        Insert(
+                            "    clg = revision.retrieve_catalog_for_path(toppath)\n",
+                        ),
+                        Insert(
+                            "    counts = {}\n",
+                        ),
+                        Insert(
+                            "    pathlen = len(toppath)\n",
+                        ),
+                        Insert(
+                            "    for dirent in clg:\n",
+                        ),
+                        Insert(
+                            "        file = dirent[0]\n",
+                        ),
+                        Insert(
+                            "        if len(file) <= pathlen:\n",
+                        ),
+                        Insert(
+                            "            continue\n",
+                        ),
+                        Insert(
+                            "        if file[0:pathlen] != toppath:\n",
+                        ),
+                        Insert(
+                            "            continue\n",
+                        ),
+                        Insert(
+                            "        slash = file.find('/', pathlen+1)\n",
+                        ),
+                        Insert(
+                            "        if slash == -1:\n",
+                        ),
+                        Insert(
+                            "            counts[file] = 0\n",
+                        ),
+                        Insert(
+                            "        else:\n",
+                        ),
+                        Insert(
+                            "            counts[file[0:slash]] += 1\n",
+                        ),
+                        Insert(
+                            "    for dir in sorted(counts, key=counts.get):\n",
+                        ),
+                        Insert(
+                            "        if counts[dir] > 0:\n",
+                        ),
+                        Insert(
+                            "            print(str(counts[dir]) + '\\t' + dir)\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "if __name__ == \"__main__\":\n",
+                        ),
+                        Insert(
+                            "    main()",
+                        ),
+                    ],
+                },
+            ],
+        },
+        Patch {
+            original: Some(
+                Filename(
+                    "a/utils/cvmfs_search",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "b/cvmfs/scripts/cvmfs_search.py",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 122,
+                        len: 7,
+                    },
+                    new_range: HunkRange {
+                        start: 122,
+                        len: 7,
+                    },
+                    function_context: Some(
+                        "def search_cvmfs_repo(url, enable_index=True):\n",
+                    ),
+                    lines: [
+                        Context(
+                            "    return ret\n",
+                        ),
+                        Context(
+                            "\n",
+                        ),
+                        Context(
+                            "\n",
+                        ),
+                        Delete(
+                            "if __name__ == \"__main__\":\n",
+                        ),
+                        Insert(
+                            "def main():\n",
+                        ),
+                        Context(
+                            "    parser = argparse.ArgumentParser(\n",
+                        ),
+                        Context(
+                            "        description=\"Search CVMFS repositories for all files matching a given download URL.\"\n",
+                        ),
+                        Context(
+                            "    )\n",
+                        ),
+                    ],
+                },
+                Hunk {
+                    old_range: HunkRange {
+                        start: 142,
+                        len: 3,
+                    },
+                    new_range: HunkRange {
+                        start: 142,
+                        len: 7,
+                    },
+                    function_context: Some(
+                        "def search_cvmfs_repo(url, enable_index=True):\n",
+                    ),
+                    lines: [
+                        Context(
+                            "    names = search_cvmfs_repo(args.url, args.db_index)\n",
+                        ),
+                        Context(
+                            "    for name in names:\n",
+                        ),
+                        Context(
+                            "        print(name)\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "if __name__ == \"__main__\":\n",
+                        ),
+                        Insert(
+                            "    main()",
+                        ),
+                    ],
+                },
+            ],
+        },
+        Patch {
+            original: Some(
+                Filename(
+                    "/dev/null",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "b/pyproject.toml",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 0,
+                        len: 0,
+                    },
+                    new_range: HunkRange {
+                        start: 1,
+                        len: 50,
+                    },
+                    function_context: None,
+                    lines: [
+                        Insert(
+                            "[build-system]\n",
+                        ),
+                        Insert(
+                            "requires = [\"setuptools>=80\", \"setuptools-scm>=8\"]\n",
+                        ),
+                        Insert(
+                            "build-backend = \"setuptools.build_meta\"\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "[project]\n",
+                        ),
+                        Insert(
+                            "name = \"python-cvmfsutils\"\n",
+                        ),
+                        Insert(
+                            "dynamic = [\"version\"]\n",
+                        ),
+                        Insert(
+                            "description = \"Inspect CernVM-FS repositories\"\n",
+                        ),
+                        Insert(
+                            "readme = \"README\"\n",
+                        ),
+                        Insert(
+                            "license = {text = \"(c) 2015 CERN - BSD License\"}\n",
+                        ),
+                        Insert(
+                            "authors = [\n",
+                        ),
+                        Insert(
+                            "    {name = \"Rene Meusel\", email = \"rene.meusel@cern.ch\"}\n",
+                        ),
+                        Insert(
+                            "]\n",
+                        ),
+                        Insert(
+                            "classifiers = [\n",
+                        ),
+                        Insert(
+                            "    \"Development Status :: 4 - Beta\",\n",
+                        ),
+                        Insert(
+                            "    \"Environment :: Console\",\n",
+                        ),
+                        Insert(
+                            "    \"Intended Audience :: Developers\",\n",
+                        ),
+                        Insert(
+                            "    \"Intended Audience :: System Administrators\",\n",
+                        ),
+                        Insert(
+                            "    \"License :: OSI Approved :: BSD License\",\n",
+                        ),
+                        Insert(
+                            "    \"Natural Language :: English\",\n",
+                        ),
+                        Insert(
+                            "    \"Operating System :: POSIX :: Linux\",\n",
+                        ),
+                        Insert(
+                            "    \"Operating System :: MacOS :: MacOS X\",\n",
+                        ),
+                        Insert(
+                            "    \"Topic :: Software Development\",\n",
+                        ),
+                        Insert(
+                            "    \"Topic :: Software Development :: Libraries :: Python Modules\",\n",
+                        ),
+                        Insert(
+                            "    \"Topic :: System :: Filesystems\",\n",
+                        ),
+                        Insert(
+                            "    \"Topic :: System :: Networking :: Monitoring\",\n",
+                        ),
+                        Insert(
+                            "    \"Topic :: System :: Systems Administration\"\n",
+                        ),
+                        Insert(
+                            "]\n",
+                        ),
+                        Insert(
+                            "dependencies = [\n",
+                        ),
+                        Insert(
+                            "    \"python-dateutil >= 1.4.1\",\n",
+                        ),
+                        Insert(
+                            "    \"requests >= 1.1.0\",\n",
+                        ),
+                        Insert(
+                            "    \"M2Crypto >= 0.20.0\"\n",
+                        ),
+                        Insert(
+                            "]\n",
+                        ),
+                        Insert(
+                            "requires-python = \">=3.6\"\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "[project.urls]\n",
+                        ),
+                        Insert(
+                            "Homepage = \"http://cernvm.cern.ch\"\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "[project.optional-dependencies]\n",
+                        ),
+                        Insert(
+                            "test = [\"xmlrunner\"]\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "[project.scripts]\n",
+                        ),
+                        Insert(
+                            "big_catalogs = \"cvmfs.scripts.big_catalogs:main\"\n",
+                        ),
+                        Insert(
+                            "catdirusage = \"cvmfs.scripts.catdirusage:main\"\n",
+                        ),
+                        Insert(
+                            "cvmfs_search = \"cvmfs.scripts.cvmfs_search:main\"\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "[tool.setuptools.packages.find]\n",
+                        ),
+                        Insert(
+                            "exclude = [\"*.test*\"]\n",
+                        ),
+                        Insert(
+                            "\n",
+                        ),
+                        Insert(
+                            "[tool.setuptools_scm]\n",
+                        ),
+                    ],
+                },
+            ],
+        },
+        Patch {
+            original: Some(
+                Filename(
+                    "a/setup.py",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "/dev/null",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 1,
+                        len: 44,
+                    },
+                    new_range: HunkRange {
+                        start: 0,
+                        len: 0,
+                    },
+                    function_context: None,
+                    lines: [
+                        Delete(
+                            "# -*- coding: utf-8 -*-\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "from setuptools import setup, find_packages\n",
+                        ),
+                        Delete(
+                            "from os         import path\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "readme_path = path.join(path.dirname(__file__), 'README')\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "setup(\n",
+                        ),
+                        Delete(
+                            "  name='python-cvmfsutils',\n",
+                        ),
+                        Delete(
+                            "  version='0.5.0',\n",
+                        ),
+                        Delete(
+                            "  url='http://cernvm.cern.ch',\n",
+                        ),
+                        Delete(
+                            "  author='Rene Meusel',\n",
+                        ),
+                        Delete(
+                            "  author_email='rene.meusel@cern.ch',\n",
+                        ),
+                        Delete(
+                            "  license='(c) 2015 CERN - BSD License',\n",
+                        ),
+                        Delete(
+                            "  description='Inspect CernVM-FS repositories',\n",
+                        ),
+                        Delete(
+                            "  # read the first paragraph\n",
+                        ),
+                        Delete(
+                            "  long_description=open(readme_path).read().split(\"\\n\\n\")[0],\n",
+                        ),
+                        Delete(
+                            "  classifiers= [\n",
+                        ),
+                        Delete(
+                            "    'Development Status :: 4 - Beta',\n",
+                        ),
+                        Delete(
+                            "    'Environment :: Console',\n",
+                        ),
+                        Delete(
+                            "    'Intended Audience :: Developers',\n",
+                        ),
+                        Delete(
+                            "    'Intended Audience :: System Administrators',\n",
+                        ),
+                        Delete(
+                            "    'License :: OSI Approved :: BSD License',\n",
+                        ),
+                        Delete(
+                            "    'Natural Language :: English',\n",
+                        ),
+                        Delete(
+                            "    'Operating System :: POSIX :: Linux',\n",
+                        ),
+                        Delete(
+                            "    'Operating System :: MacOS :: MacOS X',\n",
+                        ),
+                        Delete(
+                            "    'Topic :: Software Development',\n",
+                        ),
+                        Delete(
+                            "    'Topic :: Software Development :: Libraries :: Python Modules',\n",
+                        ),
+                        Delete(
+                            "    'Topic :: System :: Filesystems',\n",
+                        ),
+                        Delete(
+                            "    'Topic :: System :: Networking :: Monitoring',\n",
+                        ),
+                        Delete(
+                            "    'Topic :: System :: Systems Administration'\n",
+                        ),
+                        Delete(
+                            "  ],\n",
+                        ),
+                        Delete(
+                            "  packages=find_packages(),\n",
+                        ),
+                        Delete(
+                            "  scripts=['utils/big_catalogs', 'utils/catdirusage', 'utils/cvmfs_search'],\n",
+                        ),
+                        Delete(
+                            "  zip_safe=False,\n",
+                        ),
+                        Delete(
+                            "  test_suite='cvmfs.test',\n",
+                        ),
+                        Delete(
+                            "  tests_require='xmlrunner',\n",
+                        ),
+                        Delete(
+                            "  install_requires=[ # for pip; don't forget the similar RPM dependencies!\n",
+                        ),
+                        Delete(
+                            "    'python-dateutil >= 1.4.1',\n",
+                        ),
+                        Delete(
+                            "    'requests >= 1.1.0',\n",
+                        ),
+                        Delete(
+                            "    'M2Crypto >= 0.20.0'\n",
+                        ),
+                        Delete(
+                            "  ]\n",
+                        ),
+                        Delete(
+                            ")\n",
+                        ),
+                    ],
+                },
+            ],
+        },
+        Patch {
+            original: Some(
+                Filename(
+                    "a/utils/big_catalogs",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "/dev/null",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 1,
+                        len: 33,
+                    },
+                    new_range: HunkRange {
+                        start: 0,
+                        len: 0,
+                    },
+                    function_context: None,
+                    lines: [
+                        Delete(
+                            "#!/usr/bin/env python3\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "import sys\n",
+                        ),
+                        Delete(
+                            "import cvmfs\n",
+                        ),
+                        Delete(
+                            "import os\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "def usage():\n",
+                        ),
+                        Delete(
+                            "    print(\"Usage: big_catalogs <local repo name | remote repo url> [BIGNUM [BIGMB]]\")\n",
+                        ),
+                        Delete(
+                            "    print(\"  Lists all catalogs of the provided CVMFS repository with more than BIGNUM\")\n",
+                        ),
+                        Delete(
+                            "    print(\"  files in them, default 100000, or more than BIGMB megabytes, default 50.\")\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "if len(sys.argv) < 2 or len(sys.argv) > 4:\n",
+                        ),
+                        Delete(
+                            "    usage();\n",
+                        ),
+                        Delete(
+                            "    sys.exit(1)\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "repo_identifier = sys.argv[1]\n",
+                        ),
+                        Delete(
+                            "bignum = 100000\n",
+                        ),
+                        Delete(
+                            "bigmb = 50\n",
+                        ),
+                        Delete(
+                            "if len(sys.argv) > 2:\n",
+                        ),
+                        Delete(
+                            "  bignum=int(sys.argv[2])\n",
+                        ),
+                        Delete(
+                            "if len(sys.argv) > 3:\n",
+                        ),
+                        Delete(
+                            "  bigmb=int(sys.argv[3])\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "repo = cvmfs.open_repository(repo_identifier)\n",
+                        ),
+                        Delete(
+                            "revision = repo.get_current_revision()\n",
+                        ),
+                        Delete(
+                            "for clg in revision.catalogs():\n",
+                        ),
+                        Delete(
+                            "    res = clg.run_sql('SELECT count(*) FROM catalog;')\n",
+                        ),
+                        Delete(
+                            "    num_entries = res[0][0]\n",
+                        ),
+                        Delete(
+                            "    uncomp_mb = clg.db_size() / (1024*1024)\n",
+                        ),
+                        Delete(
+                            "    if (num_entries > bignum) or (uncomp_mb >= bigmb):\n",
+                        ),
+                        Delete(
+                            "        print(clg.root_prefix, num_entries, 'files',  uncomp_mb, 'MB')\n",
+                        ),
+                        Delete(
+                            "    del res\n",
+                        ),
+                        Delete(
+                            "    del clg\n",
+                        ),
+                    ],
+                },
+            ],
+        },
+        Patch {
+            original: Some(
+                Filename(
+                    "a/utils/catdirusage",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "/dev/null",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 1,
+                        len: 37,
+                    },
+                    new_range: HunkRange {
+                        start: 0,
+                        len: 0,
+                    },
+                    function_context: None,
+                    lines: [
+                        Delete(
+                            "#!/usr/bin/env python3\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "import sys\n",
+                        ),
+                        Delete(
+                            "import cvmfs\n",
+                        ),
+                        Delete(
+                            "import os\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "def usage():\n",
+                        ),
+                        Delete(
+                            "    print(\"Usage: catdirusage <local repo name | remote repo url> topdir\")\n",
+                        ),
+                        Delete(
+                            "    print(\"  Prints the number of files in the current catalog for each sub-directory\")\n",
+                        ),
+                        Delete(
+                            "    print(\"  under topdir, sorted smallest to largest.\")\n",
+                        ),
+                        Delete(
+                            "    sys.exit(1)\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "if len(sys.argv) != 3:\n",
+                        ),
+                        Delete(
+                            "    usage();\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "repo_identifier = sys.argv[1]\n",
+                        ),
+                        Delete(
+                            "toppath = sys.argv[2]\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "repo = cvmfs.open_repository(repo_identifier)\n",
+                        ),
+                        Delete(
+                            "revision = repo.get_current_revision()\n",
+                        ),
+                        Delete(
+                            "clg = revision.retrieve_catalog_for_path(toppath)\n",
+                        ),
+                        Delete(
+                            "counts = {}\n",
+                        ),
+                        Delete(
+                            "pathlen = len(toppath)\n",
+                        ),
+                        Delete(
+                            "for dirent in clg:\n",
+                        ),
+                        Delete(
+                            "    file = dirent[0]\n",
+                        ),
+                        Delete(
+                            "    if len(file) <= pathlen:\n",
+                        ),
+                        Delete(
+                            "        continue\n",
+                        ),
+                        Delete(
+                            "    if file[0:pathlen] != toppath:\n",
+                        ),
+                        Delete(
+                            "        continue\n",
+                        ),
+                        Delete(
+                            "    slash = file.find('/', pathlen+1)\n",
+                        ),
+                        Delete(
+                            "    if slash == -1:\n",
+                        ),
+                        Delete(
+                            "        counts[file] = 0\n",
+                        ),
+                        Delete(
+                            "    else:\n",
+                        ),
+                        Delete(
+                            "        counts[file[0:slash]] += 1\n",
+                        ),
+                        Delete(
+                            "for dir in sorted(counts, key=counts.get):\n",
+                        ),
+                        Delete(
+                            "    if counts[dir] > 0:\n",
+                        ),
+                        Delete(
+                            "        print(str(counts[dir]) + '\\t' + dir)\n",
+                        ),
+                    ],
+                },
+            ],
+        },
+        Patch {
+            original: Some(
+                Filename(
+                    "a/cvmfs/__init__.py",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "b/cvmfs/__init__.py",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 36,
+                        len: 7,
+                    },
+                    new_range: HunkRange {
+                        start: 36,
+                        len: 7,
+                    },
+                    function_context: Some(
+                        "def __init__(self, input_string):\n",
+                    ),
+                    lines: [
+                        Context(
+                            "\n",
+                        ),
+                        Context(
+                            "\n",
+                        ),
+                        Context(
+                            "def __extract_version_string(input_str):\n",
+                        ),
+                        Delete(
+                            "    match = re.search('.*([0-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*).*', input_str)\n",
+                        ),
+                        Insert(
+                            "    match = re.search(r'.*([0-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*).*', input_str)\n",
+                        ),
+                        Context(
+                            "    if not match or len(match.groups()) != 1:\n",
+                        ),
+                        Context(
+                            "        raise VersionNotDetected(input_str)\n",
+                        ),
+                        Context(
+                            "    return match.groups()[0]\n",
+                        ),
+                    ],
+                },
+            ],
+        },
+        Patch {
+            original: Some(
+                Filename(
+                    "a/cvmfs/scripts/big_catalogs.py",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "b/cvmfs/scripts/big_catalogs.py",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 1,
+                        len: 28,
+                    },
+                    new_range: HunkRange {
+                        start: 1,
+                        len: 38,
+                    },
+                    function_context: None,
+                    lines: [
+                        Context(
+                            "#!/usr/bin/env python3\n",
+                        ),
+                        Context(
+                            "\n",
+                        ),
+                        Delete(
+                            "import sys\n",
+                        ),
+                        Insert(
+                            "import argparse\n",
+                        ),
+                        Context(
+                            "import cvmfs\n",
+                        ),
+                        Context(
+                            "import os\n",
+                        ),
+                        Context(
+                            "\n",
+                        ),
+                        Context(
+                            "\n",
+                        ),
+                        Delete(
+                            "def usage():\n",
+                        ),
+                        Delete(
+                            "    print(\"Usage: big_catalogs <local repo name | remote repo url> [BIGNUM [BIGMB]]\")\n",
+                        ),
+                        Delete(
+                            "    print(\"  Lists all catalogs of the provided CVMFS repository with more than BIGNUM\")\n",
+                        ),
+                        Delete(
+                            "    print(\"  files in them, default 100000, or more than BIGMB megabytes, default 50.\")\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Context(
+                            "def main():\n",
+                        ),
+                        Delete(
+                            "    if len(sys.argv) < 2 or len(sys.argv) > 4:\n",
+                        ),
+                        Delete(
+                            "        usage()\n",
+                        ),
+                        Delete(
+                            "        sys.exit(1)\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "    repo_identifier = sys.argv[1]\n",
+                        ),
+                        Delete(
+                            "    bignum = 100000\n",
+                        ),
+                        Delete(
+                            "    bigmb = 50\n",
+                        ),
+                        Delete(
+                            "    if len(sys.argv) > 2:\n",
+                        ),
+                        Delete(
+                            "        bignum = int(sys.argv[2])\n",
+                        ),
+                        Delete(
+                            "    if len(sys.argv) > 3:\n",
+                        ),
+                        Delete(
+                            "        bigmb = int(sys.argv[3])\n",
+                        ),
+                        Insert(
+                            "    parser = argparse.ArgumentParser(\n",
+                        ),
+                        Insert(
+                            "        description=\"Lists all catalogs of the provided CVMFS repository with more than BIGNUM files in them or more than BIGMB megabytes.\"\n",
+                        ),
+                        Insert(
+                            "    )\n",
+                        ),
+                        Insert(
+                            "    parser.add_argument(\n",
+                        ),
+                        Insert(
+                            "        \"repo_identifier\",\n",
+                        ),
+                        Insert(
+                            "        help=\"Local repo name or remote repo url\"\n",
+                        ),
+                        Insert(
+                            "    )\n",
+                        ),
+                        Insert(
+                            "    parser.add_argument(\n",
+                        ),
+                        Insert(
+                            "        \"bignum\",\n",
+                        ),
+                        Insert(
+                            "        type=int,\n",
+                        ),
+                        Insert(
+                            "        nargs=\"?\",\n",
+                        ),
+                        Insert(
+                            "        default=100000,\n",
+                        ),
+                        Insert(
+                            "        help=\"Minimum number of files in catalog (default: 100000)\"\n",
+                        ),
+                        Insert(
+                            "    )\n",
+                        ),
+                        Insert(
+                            "    parser.add_argument(\n",
+                        ),
+                        Insert(
+                            "        \"bigmb\",\n",
+                        ),
+                        Insert(
+                            "        type=int,\n",
+                        ),
+                        Insert(
+                            "        nargs=\"?\",\n",
+                        ),
+                        Insert(
+                            "        default=50,\n",
+                        ),
+                        Insert(
+                            "        help=\"Minimum size in MB (default: 50)\"\n",
+                        ),
+                        Insert(
+                            "    )\n",
+                        ),
+                        Insert(
+                            "    \n",
+                        ),
+                        Insert(
+                            "    args = parser.parse_args()\n",
+                        ),
+                        Insert(
+                            "    \n",
+                        ),
+                        Insert(
+                            "    repo_identifier = args.repo_identifier\n",
+                        ),
+                        Insert(
+                            "    bignum = args.bignum\n",
+                        ),
+                        Insert(
+                            "    bigmb = args.bigmb\n",
+                        ),
+                        Context(
+                            "\n",
+                        ),
+                        Context(
+                            "    repo = cvmfs.open_repository(repo_identifier)\n",
+                        ),
+                        Context(
+                            "    revision = repo.get_current_revision()\n",
+                        ),
+                    ],
+                },
+            ],
+        },
+        Patch {
+            original: Some(
+                Filename(
+                    "a/cvmfs/scripts/catdirusage.py",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "b/cvmfs/scripts/catdirusage.py",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 1,
+                        len: 23,
+                    },
+                    new_range: HunkRange {
+                        start: 1,
+                        len: 27,
+                    },
+                    function_context: None,
+                    lines: [
+                        Context(
+                            "#!/usr/bin/env python3\n",
+                        ),
+                        Context(
+                            "\n",
+                        ),
+                        Delete(
+                            "import sys\n",
+                        ),
+                        Insert(
+                            "import argparse\n",
+                        ),
+                        Context(
+                            "import cvmfs\n",
+                        ),
+                        Context(
+                            "import os\n",
+                        ),
+                        Context(
+                            "\n",
+                        ),
+                        Context(
+                            "\n",
+                        ),
+                        Delete(
+                            "def usage():\n",
+                        ),
+                        Delete(
+                            "    print(\"Usage: catdirusage <local repo name | remote repo url> topdir\")\n",
+                        ),
+                        Delete(
+                            "    print(\"  Prints the number of files in the current catalog for each sub-directory\")\n",
+                        ),
+                        Delete(
+                            "    print(\"  under topdir, sorted smallest to largest.\")\n",
+                        ),
+                        Delete(
+                            "    sys.exit(1)\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Context(
+                            "def main():\n",
+                        ),
+                        Delete(
+                            "    if len(sys.argv) != 3:\n",
+                        ),
+                        Delete(
+                            "        usage()\n",
+                        ),
+                        Delete(
+                            "\n",
+                        ),
+                        Delete(
+                            "    repo_identifier = sys.argv[1]\n",
+                        ),
+                        Delete(
+                            "    toppath = sys.argv[2]\n",
+                        ),
+                        Insert(
+                            "    parser = argparse.ArgumentParser(\n",
+                        ),
+                        Insert(
+                            "        description=\"Prints the number of files in the current catalog for each sub-directory under topdir, sorted smallest to largest.\"\n",
+                        ),
+                        Insert(
+                            "    )\n",
+                        ),
+                        Insert(
+                            "    parser.add_argument(\n",
+                        ),
+                        Insert(
+                            "        \"repo_identifier\",\n",
+                        ),
+                        Insert(
+                            "        help=\"Local repo name or remote repo url\"\n",
+                        ),
+                        Insert(
+                            "    )\n",
+                        ),
+                        Insert(
+                            "    parser.add_argument(\n",
+                        ),
+                        Insert(
+                            "        \"topdir\",\n",
+                        ),
+                        Insert(
+                            "        help=\"Top directory to analyze\"\n",
+                        ),
+                        Insert(
+                            "    )\n",
+                        ),
+                        Insert(
+                            "    \n",
+                        ),
+                        Insert(
+                            "    args = parser.parse_args()\n",
+                        ),
+                        Insert(
+                            "    \n",
+                        ),
+                        Insert(
+                            "    repo_identifier = args.repo_identifier\n",
+                        ),
+                        Insert(
+                            "    toppath = args.topdir\n",
+                        ),
+                        Context(
+                            "\n",
+                        ),
+                        Context(
+                            "    repo = cvmfs.open_repository(repo_identifier)\n",
+                        ),
+                        Context(
+                            "    revision = repo.get_current_revision()\n",
+                        ),
+                    ],
+                },
+            ],
+        },
+        Patch {
+            original: Some(
+                Filename(
+                    "a/cvmfs/scripts/cvmfs_search.py",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "b/cvmfs/scripts/cvmfs_search.py",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 126,
+                        len: 7,
+                    },
+                    new_range: HunkRange {
+                        start: 126,
+                        len: 7,
+                    },
+                    function_context: Some(
+                        "def main():\n",
+                    ),
+                    lines: [
+                        Context(
+                            "    parser = argparse.ArgumentParser(\n",
+                        ),
+                        Context(
+                            "        description=\"Search CVMFS repositories for all files matching a given download URL.\"\n",
+                        ),
+                        Context(
+                            "    )\n",
+                        ),
+                        Delete(
+                            "    parser.add_argument(\"url\", type=str, help=\"A CVMFS URL to print the paths for.\")\n",
+                        ),
+                        Insert(
+                            "    parser.add_argument(\"url\", help=\"A CVMFS URL to print the paths for.\")\n",
+                        ),
+                        Context(
+                            "    parser.add_argument(\n",
+                        ),
+                        Context(
+                            "        \"--no-db-index\",\n",
+                        ),
+                        Context(
+                            "        dest=\"db_index\",\n",
+                        ),
+                    ],
+                },
+            ],
+        },
+        Patch {
+            original: Some(
+                Filename(
+                    "a/cvmfs/scripts/__init__.py",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "b/cvmfs/scripts/__init__.py",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 1,
+                        len: 1,
+                    },
+                    new_range: HunkRange {
+                        start: 1,
+                        len: 1,
+                    },
+                    function_context: None,
+                    lines: [
+                        Delete(
+                            "# Scripts module for cvmfs utilities",
+                        ),
+                        Insert(
+                            "# Scripts module for cvmfs utilities\n",
+                        ),
+                    ],
+                },
+            ],
+        },
+        Patch {
+            original: Some(
+                Filename(
+                    "a/cvmfs/scripts/big_catalogs.py",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "b/cvmfs/scripts/big_catalogs.py",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 47,
+                        len: 4,
+                    },
+                    new_range: HunkRange {
+                        start: 47,
+                        len: 4,
+                    },
+                    function_context: Some(
+                        "def main():\n",
+                    ),
+                    lines: [
+                        Context(
+                            "\n",
+                        ),
+                        Context(
+                            "\n",
+                        ),
+                        Context(
+                            "if __name__ == \"__main__\":\n",
+                        ),
+                        Delete(
+                            "    main()",
+                        ),
+                        Insert(
+                            "    main()\n",
+                        ),
+                    ],
+                },
+            ],
+        },
+        Patch {
+            original: Some(
+                Filename(
+                    "a/cvmfs/scripts/catdirusage.py",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "b/cvmfs/scripts/catdirusage.py",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 45,
+                        len: 4,
+                    },
+                    new_range: HunkRange {
+                        start: 45,
+                        len: 4,
+                    },
+                    function_context: Some(
+                        "def main():\n",
+                    ),
+                    lines: [
+                        Context(
+                            "\n",
+                        ),
+                        Context(
+                            "\n",
+                        ),
+                        Context(
+                            "if __name__ == \"__main__\":\n",
+                        ),
+                        Delete(
+                            "    main()",
+                        ),
+                        Insert(
+                            "    main()\n",
+                        ),
+                    ],
+                },
+            ],
+        },
+        Patch {
+            original: Some(
+                Filename(
+                    "a/cvmfs/scripts/cvmfs_search.py",
+                ),
+            ),
+            modified: Some(
+                Filename(
+                    "b/cvmfs/scripts/cvmfs_search.py",
+                ),
+            ),
+            hunks: [
+                Hunk {
+                    old_range: HunkRange {
+                        start: 145,
+                        len: 4,
+                    },
+                    new_range: HunkRange {
+                        start: 145,
+                        len: 4,
+                    },
+                    function_context: Some(
+                        "def main():\n",
+                    ),
+                    lines: [
+                        Context(
+                            "\n",
+                        ),
+                        Context(
+                            "\n",
+                        ),
+                        Context(
+                            "if __name__ == \"__main__\":\n",
+                        ),
+                        Delete(
+                            "    main()",
+                        ),
+                        Insert(
+                            "    main()\n",
+                        ),
+                    ],
+                },
+            ],
+        },
+    ],
+)

--- a/src/patch/test-data/40.patch
+++ b/src/patch/test-data/40.patch
@@ -1,0 +1,581 @@
+From 2e4938307ff8e53cffb15874c832b4b547b017eb Mon Sep 17 00:00:00 2001
+From: Chris Burr <christopher.burr@cern.ch>
+Date: Fri, 8 Aug 2025 06:27:08 +0200
+Subject: [PATCH 1/4] feat: migrate from setup.py to pyproject.toml with
+ entrypoints
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Replace setup.py with modern pyproject.toml configuration using setuptools-scm
+for dynamic versioning. Convert scripts to proper entrypoints in cvmfs.scripts
+module.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+---
+ cvmfs/scripts/__init__.py                     |  1 +
+ cvmfs/scripts/big_catalogs.py                 | 40 +++++++++++++++
+ cvmfs/scripts/catdirusage.py                  | 44 ++++++++++++++++
+ .../scripts/cvmfs_search.py                   |  6 ++-
+ pyproject.toml                                | 50 +++++++++++++++++++
+ setup.py                                      | 44 ----------------
+ utils/big_catalogs                            | 33 ------------
+ utils/catdirusage                             | 37 --------------
+ 8 files changed, 140 insertions(+), 115 deletions(-)
+ create mode 100644 cvmfs/scripts/__init__.py
+ create mode 100644 cvmfs/scripts/big_catalogs.py
+ create mode 100644 cvmfs/scripts/catdirusage.py
+ rename utils/cvmfs_search => cvmfs/scripts/cvmfs_search.py (99%)
+ mode change 100755 => 100644
+ create mode 100644 pyproject.toml
+ delete mode 100644 setup.py
+ delete mode 100755 utils/big_catalogs
+ delete mode 100755 utils/catdirusage
+
+diff --git a/cvmfs/scripts/__init__.py b/cvmfs/scripts/__init__.py
+new file mode 100644
+index 0000000..ed1cc7f
+--- /dev/null
++++ b/cvmfs/scripts/__init__.py
+@@ -0,0 +1 @@
++# Scripts module for cvmfs utilities
+\ No newline at end of file
+diff --git a/cvmfs/scripts/big_catalogs.py b/cvmfs/scripts/big_catalogs.py
+new file mode 100644
+index 0000000..3a5eaa4
+--- /dev/null
++++ b/cvmfs/scripts/big_catalogs.py
+@@ -0,0 +1,40 @@
++#!/usr/bin/env python3
++
++import sys
++import cvmfs
++import os
++
++
++def usage():
++    print("Usage: big_catalogs <local repo name | remote repo url> [BIGNUM [BIGMB]]")
++    print("  Lists all catalogs of the provided CVMFS repository with more than BIGNUM")
++    print("  files in them, default 100000, or more than BIGMB megabytes, default 50.")
++
++
++def main():
++    if len(sys.argv) < 2 or len(sys.argv) > 4:
++        usage()
++        sys.exit(1)
++
++    repo_identifier = sys.argv[1]
++    bignum = 100000
++    bigmb = 50
++    if len(sys.argv) > 2:
++        bignum = int(sys.argv[2])
++    if len(sys.argv) > 3:
++        bigmb = int(sys.argv[3])
++
++    repo = cvmfs.open_repository(repo_identifier)
++    revision = repo.get_current_revision()
++    for clg in revision.catalogs():
++        res = clg.run_sql('SELECT count(*) FROM catalog;')
++        num_entries = res[0][0]
++        uncomp_mb = clg.db_size() / (1024*1024)
++        if (num_entries > bignum) or (uncomp_mb >= bigmb):
++            print(clg.root_prefix, num_entries, 'files',  uncomp_mb, 'MB')
++        del res
++        del clg
++
++
++if __name__ == "__main__":
++    main()
+\ No newline at end of file
+diff --git a/cvmfs/scripts/catdirusage.py b/cvmfs/scripts/catdirusage.py
+new file mode 100644
+index 0000000..f5034c9
+--- /dev/null
++++ b/cvmfs/scripts/catdirusage.py
+@@ -0,0 +1,44 @@
++#!/usr/bin/env python3
++
++import sys
++import cvmfs
++import os
++
++
++def usage():
++    print("Usage: catdirusage <local repo name | remote repo url> topdir")
++    print("  Prints the number of files in the current catalog for each sub-directory")
++    print("  under topdir, sorted smallest to largest.")
++    sys.exit(1)
++
++
++def main():
++    if len(sys.argv) != 3:
++        usage()
++
++    repo_identifier = sys.argv[1]
++    toppath = sys.argv[2]
++
++    repo = cvmfs.open_repository(repo_identifier)
++    revision = repo.get_current_revision()
++    clg = revision.retrieve_catalog_for_path(toppath)
++    counts = {}
++    pathlen = len(toppath)
++    for dirent in clg:
++        file = dirent[0]
++        if len(file) <= pathlen:
++            continue
++        if file[0:pathlen] != toppath:
++            continue
++        slash = file.find('/', pathlen+1)
++        if slash == -1:
++            counts[file] = 0
++        else:
++            counts[file[0:slash]] += 1
++    for dir in sorted(counts, key=counts.get):
++        if counts[dir] > 0:
++            print(str(counts[dir]) + '\t' + dir)
++
++
++if __name__ == "__main__":
++    main()
+\ No newline at end of file
+diff --git a/utils/cvmfs_search b/cvmfs/scripts/cvmfs_search.py
+old mode 100755
+new mode 100644
+similarity index 99%
+rename from utils/cvmfs_search
+rename to cvmfs/scripts/cvmfs_search.py
+index 4d0c815..2a933d6
+--- a/utils/cvmfs_search
++++ b/cvmfs/scripts/cvmfs_search.py
+@@ -122,7 +122,7 @@ def search_cvmfs_repo(url, enable_index=True):
+     return ret
+ 
+ 
+-if __name__ == "__main__":
++def main():
+     parser = argparse.ArgumentParser(
+         description="Search CVMFS repositories for all files matching a given download URL."
+     )
+@@ -142,3 +142,7 @@ def search_cvmfs_repo(url, enable_index=True):
+     names = search_cvmfs_repo(args.url, args.db_index)
+     for name in names:
+         print(name)
++
++
++if __name__ == "__main__":
++    main()
+\ No newline at end of file
+diff --git a/pyproject.toml b/pyproject.toml
+new file mode 100644
+index 0000000..765195d
+--- /dev/null
++++ b/pyproject.toml
+@@ -0,0 +1,50 @@
++[build-system]
++requires = ["setuptools>=80", "setuptools-scm>=8"]
++build-backend = "setuptools.build_meta"
++
++[project]
++name = "python-cvmfsutils"
++dynamic = ["version"]
++description = "Inspect CernVM-FS repositories"
++readme = "README"
++license = {text = "(c) 2015 CERN - BSD License"}
++authors = [
++    {name = "Rene Meusel", email = "rene.meusel@cern.ch"}
++]
++classifiers = [
++    "Development Status :: 4 - Beta",
++    "Environment :: Console",
++    "Intended Audience :: Developers",
++    "Intended Audience :: System Administrators",
++    "License :: OSI Approved :: BSD License",
++    "Natural Language :: English",
++    "Operating System :: POSIX :: Linux",
++    "Operating System :: MacOS :: MacOS X",
++    "Topic :: Software Development",
++    "Topic :: Software Development :: Libraries :: Python Modules",
++    "Topic :: System :: Filesystems",
++    "Topic :: System :: Networking :: Monitoring",
++    "Topic :: System :: Systems Administration"
++]
++dependencies = [
++    "python-dateutil >= 1.4.1",
++    "requests >= 1.1.0",
++    "M2Crypto >= 0.20.0"
++]
++requires-python = ">=3.6"
++
++[project.urls]
++Homepage = "http://cernvm.cern.ch"
++
++[project.optional-dependencies]
++test = ["xmlrunner"]
++
++[project.scripts]
++big_catalogs = "cvmfs.scripts.big_catalogs:main"
++catdirusage = "cvmfs.scripts.catdirusage:main"
++cvmfs_search = "cvmfs.scripts.cvmfs_search:main"
++
++[tool.setuptools.packages.find]
++exclude = ["*.test*"]
++
++[tool.setuptools_scm]
+diff --git a/setup.py b/setup.py
+deleted file mode 100644
+index e069962..0000000
+--- a/setup.py
++++ /dev/null
+@@ -1,44 +0,0 @@
+-# -*- coding: utf-8 -*-
+-
+-from setuptools import setup, find_packages
+-from os         import path
+-
+-
+-readme_path = path.join(path.dirname(__file__), 'README')
+-
+-setup(
+-  name='python-cvmfsutils',
+-  version='0.5.0',
+-  url='http://cernvm.cern.ch',
+-  author='Rene Meusel',
+-  author_email='rene.meusel@cern.ch',
+-  license='(c) 2015 CERN - BSD License',
+-  description='Inspect CernVM-FS repositories',
+-  # read the first paragraph
+-  long_description=open(readme_path).read().split("\n\n")[0],
+-  classifiers= [
+-    'Development Status :: 4 - Beta',
+-    'Environment :: Console',
+-    'Intended Audience :: Developers',
+-    'Intended Audience :: System Administrators',
+-    'License :: OSI Approved :: BSD License',
+-    'Natural Language :: English',
+-    'Operating System :: POSIX :: Linux',
+-    'Operating System :: MacOS :: MacOS X',
+-    'Topic :: Software Development',
+-    'Topic :: Software Development :: Libraries :: Python Modules',
+-    'Topic :: System :: Filesystems',
+-    'Topic :: System :: Networking :: Monitoring',
+-    'Topic :: System :: Systems Administration'
+-  ],
+-  packages=find_packages(),
+-  scripts=['utils/big_catalogs', 'utils/catdirusage', 'utils/cvmfs_search'],
+-  zip_safe=False,
+-  test_suite='cvmfs.test',
+-  tests_require='xmlrunner',
+-  install_requires=[ # for pip; don't forget the similar RPM dependencies!
+-    'python-dateutil >= 1.4.1',
+-    'requests >= 1.1.0',
+-    'M2Crypto >= 0.20.0'
+-  ]
+-)
+diff --git a/utils/big_catalogs b/utils/big_catalogs
+deleted file mode 100755
+index d9aea6e..0000000
+--- a/utils/big_catalogs
++++ /dev/null
+@@ -1,33 +0,0 @@
+-#!/usr/bin/env python3
+-
+-import sys
+-import cvmfs
+-import os
+-
+-def usage():
+-    print("Usage: big_catalogs <local repo name | remote repo url> [BIGNUM [BIGMB]]")
+-    print("  Lists all catalogs of the provided CVMFS repository with more than BIGNUM")
+-    print("  files in them, default 100000, or more than BIGMB megabytes, default 50.")
+-
+-if len(sys.argv) < 2 or len(sys.argv) > 4:
+-    usage();
+-    sys.exit(1)
+-
+-repo_identifier = sys.argv[1]
+-bignum = 100000
+-bigmb = 50
+-if len(sys.argv) > 2:
+-  bignum=int(sys.argv[2])
+-if len(sys.argv) > 3:
+-  bigmb=int(sys.argv[3])
+-
+-repo = cvmfs.open_repository(repo_identifier)
+-revision = repo.get_current_revision()
+-for clg in revision.catalogs():
+-    res = clg.run_sql('SELECT count(*) FROM catalog;')
+-    num_entries = res[0][0]
+-    uncomp_mb = clg.db_size() / (1024*1024)
+-    if (num_entries > bignum) or (uncomp_mb >= bigmb):
+-        print(clg.root_prefix, num_entries, 'files',  uncomp_mb, 'MB')
+-    del res
+-    del clg
+diff --git a/utils/catdirusage b/utils/catdirusage
+deleted file mode 100755
+index 2679ebe..0000000
+--- a/utils/catdirusage
++++ /dev/null
+@@ -1,37 +0,0 @@
+-#!/usr/bin/env python3
+-
+-import sys
+-import cvmfs
+-import os
+-
+-def usage():
+-    print("Usage: catdirusage <local repo name | remote repo url> topdir")
+-    print("  Prints the number of files in the current catalog for each sub-directory")
+-    print("  under topdir, sorted smallest to largest.")
+-    sys.exit(1)
+-
+-if len(sys.argv) != 3:
+-    usage();
+-
+-repo_identifier = sys.argv[1]
+-toppath = sys.argv[2]
+-
+-repo = cvmfs.open_repository(repo_identifier)
+-revision = repo.get_current_revision()
+-clg = revision.retrieve_catalog_for_path(toppath)
+-counts = {}
+-pathlen = len(toppath)
+-for dirent in clg:
+-    file = dirent[0]
+-    if len(file) <= pathlen:
+-        continue
+-    if file[0:pathlen] != toppath:
+-        continue
+-    slash = file.find('/', pathlen+1)
+-    if slash == -1:
+-        counts[file] = 0
+-    else:
+-        counts[file[0:slash]] += 1
+-for dir in sorted(counts, key=counts.get):
+-    if counts[dir] > 0:
+-        print(str(counts[dir]) + '\t' + dir)
+
+From ef1bd9fb3485c122490058db203b366d48955380 Mon Sep 17 00:00:00 2001
+From: Chris Burr <christopher.burr@cern.ch>
+Date: Fri, 8 Aug 2025 06:28:45 +0200
+Subject: [PATCH 2/4] fix: use raw string for regex to avoid SyntaxWarning
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+---
+ cvmfs/__init__.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cvmfs/__init__.py b/cvmfs/__init__.py
+index 6aad449..aa035d6 100644
+--- a/cvmfs/__init__.py
++++ b/cvmfs/__init__.py
+@@ -36,7 +36,7 @@ def __init__(self, input_string):
+ 
+ 
+ def __extract_version_string(input_str):
+-    match = re.search('.*([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*).*', input_str)
++    match = re.search(r'.*([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*).*', input_str)
+     if not match or len(match.groups()) != 1:
+         raise VersionNotDetected(input_str)
+     return match.groups()[0]
+
+From 2b9927f07151e785c55be7763bdef2a982b56b59 Mon Sep 17 00:00:00 2001
+From: Chris Burr <christopher.burr@cern.ch>
+Date: Fri, 8 Aug 2025 06:35:34 +0200
+Subject: [PATCH 3/4] refactor: convert entrypoints to use argparse
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Replace manual sys.argv parsing with argparse for better argument handling
+and help messages. All scripts now provide proper --help output, automatic
+type validation, and consistent error messages.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+---
+ cvmfs/scripts/big_catalogs.py | 46 +++++++++++++++++++++--------------
+ cvmfs/scripts/catdirusage.py  | 30 +++++++++++++----------
+ cvmfs/scripts/cvmfs_search.py |  2 +-
+ 3 files changed, 46 insertions(+), 32 deletions(-)
+
+diff --git a/cvmfs/scripts/big_catalogs.py b/cvmfs/scripts/big_catalogs.py
+index 3a5eaa4..2893f7f 100644
+--- a/cvmfs/scripts/big_catalogs.py
++++ b/cvmfs/scripts/big_catalogs.py
+@@ -1,28 +1,38 @@
+ #!/usr/bin/env python3
+ 
+-import sys
++import argparse
+ import cvmfs
+ import os
+ 
+ 
+-def usage():
+-    print("Usage: big_catalogs <local repo name | remote repo url> [BIGNUM [BIGMB]]")
+-    print("  Lists all catalogs of the provided CVMFS repository with more than BIGNUM")
+-    print("  files in them, default 100000, or more than BIGMB megabytes, default 50.")
+-
+-
+ def main():
+-    if len(sys.argv) < 2 or len(sys.argv) > 4:
+-        usage()
+-        sys.exit(1)
+-
+-    repo_identifier = sys.argv[1]
+-    bignum = 100000
+-    bigmb = 50
+-    if len(sys.argv) > 2:
+-        bignum = int(sys.argv[2])
+-    if len(sys.argv) > 3:
+-        bigmb = int(sys.argv[3])
++    parser = argparse.ArgumentParser(
++        description="Lists all catalogs of the provided CVMFS repository with more than BIGNUM files in them or more than BIGMB megabytes."
++    )
++    parser.add_argument(
++        "repo_identifier",
++        help="Local repo name or remote repo url"
++    )
++    parser.add_argument(
++        "bignum",
++        type=int,
++        nargs="?",
++        default=100000,
++        help="Minimum number of files in catalog (default: 100000)"
++    )
++    parser.add_argument(
++        "bigmb",
++        type=int,
++        nargs="?",
++        default=50,
++        help="Minimum size in MB (default: 50)"
++    )
++    
++    args = parser.parse_args()
++    
++    repo_identifier = args.repo_identifier
++    bignum = args.bignum
++    bigmb = args.bigmb
+ 
+     repo = cvmfs.open_repository(repo_identifier)
+     revision = repo.get_current_revision()
+diff --git a/cvmfs/scripts/catdirusage.py b/cvmfs/scripts/catdirusage.py
+index f5034c9..e6e83e9 100644
+--- a/cvmfs/scripts/catdirusage.py
++++ b/cvmfs/scripts/catdirusage.py
+@@ -1,23 +1,27 @@
+ #!/usr/bin/env python3
+ 
+-import sys
++import argparse
+ import cvmfs
+ import os
+ 
+ 
+-def usage():
+-    print("Usage: catdirusage <local repo name | remote repo url> topdir")
+-    print("  Prints the number of files in the current catalog for each sub-directory")
+-    print("  under topdir, sorted smallest to largest.")
+-    sys.exit(1)
+-
+-
+ def main():
+-    if len(sys.argv) != 3:
+-        usage()
+-
+-    repo_identifier = sys.argv[1]
+-    toppath = sys.argv[2]
++    parser = argparse.ArgumentParser(
++        description="Prints the number of files in the current catalog for each sub-directory under topdir, sorted smallest to largest."
++    )
++    parser.add_argument(
++        "repo_identifier",
++        help="Local repo name or remote repo url"
++    )
++    parser.add_argument(
++        "topdir",
++        help="Top directory to analyze"
++    )
++    
++    args = parser.parse_args()
++    
++    repo_identifier = args.repo_identifier
++    toppath = args.topdir
+ 
+     repo = cvmfs.open_repository(repo_identifier)
+     revision = repo.get_current_revision()
+diff --git a/cvmfs/scripts/cvmfs_search.py b/cvmfs/scripts/cvmfs_search.py
+index 2a933d6..7799ef7 100644
+--- a/cvmfs/scripts/cvmfs_search.py
++++ b/cvmfs/scripts/cvmfs_search.py
+@@ -126,7 +126,7 @@ def main():
+     parser = argparse.ArgumentParser(
+         description="Search CVMFS repositories for all files matching a given download URL."
+     )
+-    parser.add_argument("url", type=str, help="A CVMFS URL to print the paths for.")
++    parser.add_argument("url", help="A CVMFS URL to print the paths for.")
+     parser.add_argument(
+         "--no-db-index",
+         dest="db_index",
+
+From 42877482a21612ddeddc58b34bb618dbf9b3bafe Mon Sep 17 00:00:00 2001
+From: Chris Burr <christopher.burr@cern.ch>
+Date: Fri, 8 Aug 2025 06:38:38 +0200
+Subject: [PATCH 4/4] fix: add missing newlines at end of files
+
+---
+ cvmfs/scripts/__init__.py     | 2 +-
+ cvmfs/scripts/big_catalogs.py | 2 +-
+ cvmfs/scripts/catdirusage.py  | 2 +-
+ cvmfs/scripts/cvmfs_search.py | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/cvmfs/scripts/__init__.py b/cvmfs/scripts/__init__.py
+index ed1cc7f..2d56b66 100644
+--- a/cvmfs/scripts/__init__.py
++++ b/cvmfs/scripts/__init__.py
+@@ -1 +1 @@
+-# Scripts module for cvmfs utilities
+\ No newline at end of file
++# Scripts module for cvmfs utilities
+diff --git a/cvmfs/scripts/big_catalogs.py b/cvmfs/scripts/big_catalogs.py
+index 2893f7f..4694611 100644
+--- a/cvmfs/scripts/big_catalogs.py
++++ b/cvmfs/scripts/big_catalogs.py
+@@ -47,4 +47,4 @@ def main():
+ 
+ 
+ if __name__ == "__main__":
+-    main()
+\ No newline at end of file
++    main()
+diff --git a/cvmfs/scripts/catdirusage.py b/cvmfs/scripts/catdirusage.py
+index e6e83e9..bd3c791 100644
+--- a/cvmfs/scripts/catdirusage.py
++++ b/cvmfs/scripts/catdirusage.py
+@@ -45,4 +45,4 @@ def main():
+ 
+ 
+ if __name__ == "__main__":
+-    main()
+\ No newline at end of file
++    main()
+diff --git a/cvmfs/scripts/cvmfs_search.py b/cvmfs/scripts/cvmfs_search.py
+index 7799ef7..d02f42c 100644
+--- a/cvmfs/scripts/cvmfs_search.py
++++ b/cvmfs/scripts/cvmfs_search.py
+@@ -145,4 +145,4 @@ def main():
+ 
+ 
+ if __name__ == "__main__":
+-    main()
+\ No newline at end of file
++    main()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 //! Common utilities
 
 use std::{
-    collections::{HashMap, hash_map::Entry},
+    collections::{hash_map::Entry, HashMap},
     hash::Hash,
 };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -99,7 +99,7 @@ pub trait Text: Eq + Hash {
     fn as_str(&self) -> Option<&str>;
     fn as_bytes(&self) -> &[u8];
     #[allow(unused)]
-    fn lines(&self) -> LineIter<Self>;
+    fn lines(&self) -> LineIter<'_, Self>;
 
     fn parse<T: std::str::FromStr>(&self) -> Option<T> {
         self.as_str().and_then(|s| s.parse().ok())
@@ -152,7 +152,7 @@ impl Text for str {
         self.as_bytes()
     }
 
-    fn lines(&self) -> LineIter<Self> {
+    fn lines(&self) -> LineIter<'_, Self> {
         LineIter::new(self)
     }
 }
@@ -202,7 +202,7 @@ impl Text for [u8] {
         self
     }
 
-    fn lines(&self) -> LineIter<Self> {
+    fn lines(&self) -> LineIter<'_, Self> {
         LineIter::new(self)
     }
 }


### PR DESCRIPTION
closes https://github.com/prefix-dev/rattler-build/issues/1819

issue was actually simpler than i thought. patch is a git-format-patch with 40 patches inside of it as 4 commits. we were not parsing git-metadata with "From" boundary, so we were failing to parse git-format-patches correctly. I also added another test to check if we could parse correctly if we encounter from with diff prefixes, just in case.